### PR TITLE
feat ( #16 ) : 토큰을 받아서 유저의 정보를 받아오는 로직 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,6 +62,9 @@ plugins {
         //swagger
         implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
 
+        //s3
+        //implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3:3.0.0'
+
 
 
 

--- a/src/main/java/whispy_server/whispy/domain/user/adapter/in/web/controller/UserController.java
+++ b/src/main/java/whispy_server/whispy/domain/user/adapter/in/web/controller/UserController.java
@@ -10,9 +10,11 @@ import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
+import whispy_server.whispy.domain.user.adapter.in.web.dto.request.KakaoOauthTokenRequest;
 import whispy_server.whispy.domain.user.adapter.in.web.dto.request.RegisterRequest;
 import whispy_server.whispy.domain.user.adapter.in.web.dto.request.UserLoginRequest;
 import whispy_server.whispy.domain.user.adapter.in.web.dto.response.TokenResponse;
+import whispy_server.whispy.domain.user.application.port.in.KakaoOauthUseCase;
 import whispy_server.whispy.domain.user.application.port.in.UserLoginUseCase;
 import whispy_server.whispy.domain.user.application.port.in.UserRegisterUseCase;
 import whispy_server.whispy.domain.user.application.port.in.UserTokenReissueUseCase;
@@ -26,6 +28,7 @@ public class UserController implements UserApiDocument {
     private final UserLoginUseCase userLoginUseCase;
     private final UserRegisterUseCase userRegisterUseCase;
     private final UserTokenReissueUseCase userTokenReissueUseCase;
+    private final KakaoOauthUseCase kakaoOauthUseCase;
 
     @PostMapping("/login")
     public TokenResponse login(@Valid  @RequestBody UserLoginRequest request) {
@@ -38,12 +41,13 @@ public class UserController implements UserApiDocument {
         userRegisterUseCase.register(request);
     }
 
+    @PostMapping("/oauth/kakao")
+    public TokenResponse authenticateWithKakaoToken(@Valid @RequestBody KakaoOauthTokenRequest request){
+        return kakaoOauthUseCase.loginWithKakao(request.accessToken());
+    }
+
     @PutMapping("/reissue")
     public TokenResponse reissue(@RequestHeader("X-Refresh-Token") String token) {
         return userTokenReissueUseCase.reissue(token);
     }
-
-
-
-
 }

--- a/src/main/java/whispy_server/whispy/domain/user/adapter/in/web/dto/request/KakaoOauthTokenRequest.java
+++ b/src/main/java/whispy_server/whispy/domain/user/adapter/in/web/dto/request/KakaoOauthTokenRequest.java
@@ -1,0 +1,9 @@
+package whispy_server.whispy.domain.user.adapter.in.web.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record KakaoOauthTokenRequest(
+        @NotBlank
+        String accessToken
+) {
+}

--- a/src/main/java/whispy_server/whispy/domain/user/adapter/in/web/dto/request/UserLoginRequest.java
+++ b/src/main/java/whispy_server/whispy/domain/user/adapter/in/web/dto/request/UserLoginRequest.java
@@ -1,14 +1,14 @@
 package whispy_server.whispy.domain.user.adapter.in.web.dto.request;
 
 import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 
 public record UserLoginRequest(
 
     @Email
     String email,
-    @Pattern(regexp = "^(?=.*[0-9])(?=.*[!@#$%^&*()_+\\-=\\[\\]{};':\"\\\\|,.<>\\/?]).{8,}$",
-            message = "비밀번호는 8자 이상, 숫자 1개 이상, 특수문자 1개 이상 포함해야 합니다.")
+    @NotBlank
     String password
 ) {
 }

--- a/src/main/java/whispy_server/whispy/domain/user/adapter/out/entity/UserJpaEntity.java
+++ b/src/main/java/whispy_server/whispy/domain/user/adapter/out/entity/UserJpaEntity.java
@@ -32,7 +32,7 @@ public class UserJpaEntity {
     @Column(name = "email", nullable = false, unique = true)
     private String email;
 
-    @Column(name = "password", columnDefinition = "CHAR(60)", nullable = false)
+    @Column(name = "password", columnDefinition = "CHAR(70)", nullable = false)
     private String password;
 
     @Column(name = "name", columnDefinition = "CHAR(30)", nullable = false)

--- a/src/main/java/whispy_server/whispy/domain/user/application/port/in/KakaoOauthUseCase.java
+++ b/src/main/java/whispy_server/whispy/domain/user/application/port/in/KakaoOauthUseCase.java
@@ -1,0 +1,8 @@
+package whispy_server.whispy.domain.user.application.port.in;
+
+import whispy_server.whispy.domain.user.adapter.in.web.dto.response.TokenResponse;
+
+public interface KakaoOauthUseCase {
+
+    TokenResponse loginWithKakao(String accessToken);
+}

--- a/src/main/java/whispy_server/whispy/domain/user/application/service/KakaoOauthService.java
+++ b/src/main/java/whispy_server/whispy/domain/user/application/service/KakaoOauthService.java
@@ -1,8 +1,8 @@
 package whispy_server.whispy.domain.user.application.service;
 
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import whispy_server.whispy.domain.user.adapter.in.web.dto.response.TokenResponse;
 import whispy_server.whispy.domain.user.application.port.in.KakaoOauthUseCase;
 import whispy_server.whispy.domain.user.application.port.in.OauthUserUseCase;

--- a/src/main/java/whispy_server/whispy/domain/user/application/service/KakaoOauthService.java
+++ b/src/main/java/whispy_server/whispy/domain/user/application/service/KakaoOauthService.java
@@ -1,0 +1,34 @@
+package whispy_server.whispy.domain.user.application.service;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import whispy_server.whispy.domain.user.adapter.in.web.dto.response.TokenResponse;
+import whispy_server.whispy.domain.user.application.port.in.KakaoOauthUseCase;
+import whispy_server.whispy.domain.user.application.port.in.OauthUserUseCase;
+import whispy_server.whispy.domain.user.model.User;
+import whispy_server.whispy.global.oauth.client.KakaoOauthClient;
+import whispy_server.whispy.global.oauth.dto.OauthUserInfo;
+import whispy_server.whispy.global.oauth.parser.KakaoOauthUserInfoParser;
+import whispy_server.whispy.global.security.jwt.JwtTokenProvider;
+
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class KakaoOauthService implements KakaoOauthUseCase {
+
+    private final KakaoOauthClient kakaoOauthClient;
+    private final OauthUserUseCase oauthUserUseCase;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    @Transactional
+    public TokenResponse loginWithKakao(String accessToken){
+        Map<String, Object> userAttribute = kakaoOauthClient.fetchUserInfo(accessToken) ;
+        OauthUserInfo oauthUserInfo = new KakaoOauthUserInfoParser().parse(userAttribute);
+        User user = oauthUserUseCase.findOrCreateOauthUser(oauthUserInfo, "kakao");
+
+        return jwtTokenProvider.generateToken(user.email(), user.role().name());
+    }
+}

--- a/src/main/java/whispy_server/whispy/domain/user/application/service/OauthUserService.java
+++ b/src/main/java/whispy_server/whispy/domain/user/application/service/OauthUserService.java
@@ -1,10 +1,10 @@
 package whispy_server.whispy.domain.user.application.service;
 
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import whispy_server.whispy.domain.user.model.User;
 import whispy_server.whispy.domain.user.application.port.in.OauthUserUseCase;
 import whispy_server.whispy.domain.user.application.port.out.QueryUserPort;

--- a/src/main/java/whispy_server/whispy/domain/user/application/service/OauthUserService.java
+++ b/src/main/java/whispy_server/whispy/domain/user/application/service/OauthUserService.java
@@ -2,6 +2,8 @@ package whispy_server.whispy.domain.user.application.service;
 
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+
 import org.springframework.stereotype.Service;
 import whispy_server.whispy.domain.user.model.User;
 import whispy_server.whispy.domain.user.application.port.in.OauthUserUseCase;
@@ -17,11 +19,14 @@ public class OauthUserService implements OauthUserUseCase {
     private final QueryUserPort queryUserPort;
     private final UserSavePort userSavePort;
 
+    @Value("${spring.oauth.default-password}")
+    private String defaultPassword;
+
     @Override
     public User findOrCreateOauthUser(OauthUserInfo oauthUserInfo, String provider) {
         return queryUserPort.findByEmail(oauthUserInfo.email())
                 .orElseGet(() -> {
-                    User newUser = oauthUserInfo.toUserInfo(provider);
+                    User newUser = oauthUserInfo.toUserInfo(provider, defaultPassword);
                     userSavePort.save(newUser);
                     return newUser;
                 });

--- a/src/main/java/whispy_server/whispy/domain/user/application/service/UserLoginService.java
+++ b/src/main/java/whispy_server/whispy/domain/user/application/service/UserLoginService.java
@@ -1,9 +1,9 @@
 package whispy_server.whispy.domain.user.application.service;
 
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import whispy_server.whispy.domain.auth.adapter.out.entity.types.Role;
 import whispy_server.whispy.domain.user.adapter.in.web.dto.request.UserLoginRequest;
 import whispy_server.whispy.domain.user.adapter.in.web.dto.response.TokenResponse;

--- a/src/main/java/whispy_server/whispy/domain/user/application/service/UserLoginService.java
+++ b/src/main/java/whispy_server/whispy/domain/user/application/service/UserLoginService.java
@@ -7,7 +7,6 @@ import org.springframework.stereotype.Service;
 import whispy_server.whispy.domain.auth.adapter.out.entity.types.Role;
 import whispy_server.whispy.domain.user.adapter.in.web.dto.request.UserLoginRequest;
 import whispy_server.whispy.domain.user.adapter.in.web.dto.response.TokenResponse;
-import whispy_server.whispy.domain.user.adapter.out.persistence.repository.UserRepository;
 import whispy_server.whispy.domain.user.model.User;
 import whispy_server.whispy.domain.user.application.port.in.UserLoginUseCase;
 import whispy_server.whispy.domain.user.application.port.out.QueryUserPort;
@@ -19,7 +18,6 @@ import whispy_server.whispy.global.security.jwt.JwtTokenProvider;
 @RequiredArgsConstructor
 public class UserLoginService implements UserLoginUseCase {
 
-    private final UserRepository  userRepository;
     private final JwtTokenProvider  jwtTokenProvider;
     private final PasswordEncoder passwordEncoder;
     private final QueryUserPort queryUserPort;

--- a/src/main/java/whispy_server/whispy/domain/user/application/service/UserRegisterService.java
+++ b/src/main/java/whispy_server/whispy/domain/user/application/service/UserRegisterService.java
@@ -1,9 +1,10 @@
 package whispy_server.whispy.domain.user.application.service;
 
-import jakarta.transaction.Transactional;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import whispy_server.whispy.domain.auth.adapter.out.entity.types.Role;
 import whispy_server.whispy.domain.user.adapter.in.web.dto.request.RegisterRequest;
 import whispy_server.whispy.domain.user.model.User;

--- a/src/main/java/whispy_server/whispy/domain/user/application/service/UserTokenReissueService.java
+++ b/src/main/java/whispy_server/whispy/domain/user/application/service/UserTokenReissueService.java
@@ -1,8 +1,8 @@
 package whispy_server.whispy.domain.user.application.service;
 
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import whispy_server.whispy.domain.user.adapter.in.web.dto.response.TokenResponse;
 import whispy_server.whispy.domain.user.application.port.in.UserTokenReissueUseCase;
 import whispy_server.whispy.global.security.jwt.JwtTokenProvider;

--- a/src/main/java/whispy_server/whispy/global/config/rest/RestTemplateConfig.java
+++ b/src/main/java/whispy_server/whispy/global/config/rest/RestTemplateConfig.java
@@ -1,0 +1,14 @@
+package whispy_server.whispy.global.config.rest;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/src/main/java/whispy_server/whispy/global/config/security/SecurityConfig.java
+++ b/src/main/java/whispy_server/whispy/global/config/security/SecurityConfig.java
@@ -17,7 +17,7 @@ import whispy_server.whispy.global.config.filter.FilterConfig;
 import whispy_server.whispy.global.oauth.handler.OauthFailureHandler;
 import whispy_server.whispy.global.oauth.handler.OauthSuccessHandler;
 import whispy_server.whispy.global.security.jwt.JwtTokenProvider;
-import whispy_server.whispy.global.security.oauth.CustomOauthUserService;
+import whispy_server.whispy.global.security.auth.CustomOauthUserDetailsService;
 
 @EnableWebSecurity
 @RequiredArgsConstructor
@@ -28,7 +28,7 @@ public class SecurityConfig {
     private final JwtTokenProvider jwtTokenProvider;
     private final OauthSuccessHandler oauthSuccessHandler;
     private final OauthFailureHandler oauthFailureHandler;
-    private final CustomOauthUserService customOauthUserService;
+    private final CustomOauthUserDetailsService customOauthUserService;
 
     @Bean
     public BCryptPasswordEncoder bCryptPasswordEncoder(){
@@ -63,8 +63,9 @@ public class SecurityConfig {
                 )
 
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/oauth2/**", "/login/oauth2/**").permitAll()
+                        .requestMatchers("/oauth2/authorization/google", "/login/oauth2/code/google").permitAll()
                         .requestMatchers("/users/login","/users/register","/users/reissue").permitAll()
+                        .requestMatchers("/users/oauth/kakao").permitAll()
                         .requestMatchers("/oauth/success/**").permitAll()
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/v3/api-docs.yaml").permitAll()
                         .requestMatchers("/").permitAll()

--- a/src/main/java/whispy_server/whispy/global/exception/domain/oauth/InvalidKakaoAccessTokenException.java
+++ b/src/main/java/whispy_server/whispy/global/exception/domain/oauth/InvalidKakaoAccessTokenException.java
@@ -1,0 +1,13 @@
+package whispy_server.whispy.global.exception.domain.oauth;
+
+import whispy_server.whispy.global.exception.WhispyException;
+import whispy_server.whispy.global.exception.error.ErrorCode;
+
+public class InvalidKakaoAccessTokenException extends WhispyException {
+
+    public static final WhispyException EXCEPTION = new InvalidKakaoAccessTokenException();
+
+    public InvalidKakaoAccessTokenException() {
+        super(ErrorCode.INVALID_KAKAO_ACCESS_TOKEN);
+    }
+}

--- a/src/main/java/whispy_server/whispy/global/exception/domain/oauth/InvalidKakaoOauthResponseException.java
+++ b/src/main/java/whispy_server/whispy/global/exception/domain/oauth/InvalidKakaoOauthResponseException.java
@@ -1,0 +1,13 @@
+package whispy_server.whispy.global.exception.domain.oauth;
+
+import whispy_server.whispy.global.exception.WhispyException;
+import whispy_server.whispy.global.exception.error.ErrorCode;
+
+public class InvalidKakaoOauthResponseException extends WhispyException {
+
+    public static final WhispyException EXCEPTION = new InvalidKakaoOauthResponseException();
+
+    public InvalidKakaoOauthResponseException() {
+        super(ErrorCode.INVALID_KAKAO_OAUTH_RESPONSE);
+    }
+}

--- a/src/main/java/whispy_server/whispy/global/exception/error/ErrorCode.java
+++ b/src/main/java/whispy_server/whispy/global/exception/error/ErrorCode.java
@@ -12,12 +12,15 @@ public enum ErrorCode {
 
     INTERNAL_SERVER_ERROR(500, "서버 오류 발생"),
 
+    INVALID_KAKAO_OAUTH_RESPONSE(400, "OAuth 응답이 유효하지 않습니다."),
+
     USER_NOT_FOUND(404, "일치하는 유저를 찾을 수 없습니다"),
     ADMIN_NOT_FOUND(404, "일치하는 어드민을 찾을 수 없습니다"),
 
     FEIGN_UNAUTHORIZED(401, "Feign UnAuthorized"),
     INVALID_TOKEN(401, "Invalid Token"),
-    EXPIRED_TOKEN(401, "Expired Token"),
+    INVALID_KAKAO_ACCESS_TOKEN(401, "유효하지 않은 kakao access 토큰입니다."),
+    EXPIRED_TOKEN(401, "토큰이 만료 되었습니다."),
     OAUTH_AUTHENTICATION_FAILED(401, "OAuth2 인증에 실패했습니다"),
     PASSWORD_MISS_MATCH(401, "비밀번호가 일치하지 않습니다"),
 

--- a/src/main/java/whispy_server/whispy/global/exception/error/ErrorResponse.java
+++ b/src/main/java/whispy_server/whispy/global/exception/error/ErrorResponse.java
@@ -3,7 +3,6 @@ package whispy_server.whispy.global.exception.error;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.Builder;
 
-import javax.print.DocFlavor;
 import java.time.LocalDateTime;
 
 @Builder

--- a/src/main/java/whispy_server/whispy/global/oauth/dto/OauthUserInfo.java
+++ b/src/main/java/whispy_server/whispy/global/oauth/dto/OauthUserInfo.java
@@ -5,17 +5,15 @@ import whispy_server.whispy.domain.user.model.User;
 import whispy_server.whispy.domain.user.model.types.Gender;
 import whispy_server.whispy.domain.user.model.vo.Profile;
 
-import java.util.UUID;
 
 public record OauthUserInfo(String name, String email, String profileImage) {
-    private static final String DEFAULT_PASSWORD = "OAUTH_USER";
 
-    public User toUserInfo(String provider) {
+    public User toUserInfo(String provider, String defaultPassword) {
         return new User(
-                UUID.randomUUID(),
+                null,
                 email,
-                DEFAULT_PASSWORD, //todo 고쳐야 함 이거 password
-                new Profile(name, profileImage,Gender.UNKNOWN),
+                defaultPassword,
+                new Profile(name, profileImage, Gender.UNKNOWN),
                 Role.USER,
                 true,
                 0,

--- a/src/main/java/whispy_server/whispy/global/oauth/service/KakaoTokenValidator.java
+++ b/src/main/java/whispy_server/whispy/global/oauth/service/KakaoTokenValidator.java
@@ -1,0 +1,53 @@
+package whispy_server.whispy.global.oauth.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestTemplate;
+
+
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class KakaoTokenValidator {
+
+    private final RestTemplate restTemplate;
+    private static final String USER_INFO_URL = "https://kapi.kakao.com/v2/user/me";
+
+    public Map<String, Object> validateTokenAndGetUserInfo(String accessToken) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(accessToken);
+
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+
+        try {
+
+            ResponseEntity<Map<String, Object>> response = restTemplate.exchange(
+                    USER_INFO_URL,
+                    HttpMethod.GET,
+                    entity,
+                    new ParameterizedTypeReference<Map<String, Object>>() {
+                    }
+            );
+
+            Map<String, Object> userInfo = response.getBody();
+            if (userInfo == null) {
+                throw new IllegalArgumentException("dd");
+            }
+            return userInfo;
+
+        } catch (HttpClientErrorException e) {
+            if (e.getStatusCode() == HttpStatus.UNAUTHORIZED) {
+                throw new IllegalArgumentException("d");
+            }
+            throw new IllegalArgumentException("dd");
+        }
+    }
+}

--- a/src/main/java/whispy_server/whispy/global/security/auth/CustomOauthUserDetailsService.java
+++ b/src/main/java/whispy_server/whispy/global/security/auth/CustomOauthUserDetailsService.java
@@ -1,12 +1,12 @@
 package whispy_server.whispy.global.security.auth;
 
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import whispy_server.whispy.domain.user.model.User;
 import whispy_server.whispy.domain.user.application.port.in.OauthUserUseCase;
 import whispy_server.whispy.global.oauth.dto.OauthUserInfo;

--- a/src/main/java/whispy_server/whispy/global/security/auth/CustomOauthUserDetailsService.java
+++ b/src/main/java/whispy_server/whispy/global/security/auth/CustomOauthUserDetailsService.java
@@ -1,4 +1,4 @@
-package whispy_server.whispy.global.security.oauth;
+package whispy_server.whispy.global.security.auth;
 
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -11,11 +11,10 @@ import whispy_server.whispy.domain.user.model.User;
 import whispy_server.whispy.domain.user.application.port.in.OauthUserUseCase;
 import whispy_server.whispy.global.oauth.dto.OauthUserInfo;
 import whispy_server.whispy.global.oauth.parser.factory.OauthUserInfoParserFactory;
-import whispy_server.whispy.global.security.auth.AuthDetails;
 
 @RequiredArgsConstructor
 @Service
-public class CustomOauthUserService extends DefaultOAuth2UserService {
+public class CustomOauthUserDetailsService extends DefaultOAuth2UserService {
 
     private final OauthUserUseCase oauthUserUseCase;
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,11 +8,11 @@ spring:
   jpa:
     hibernate:
       ddl-auto: update
-    show-sql: false
+    show-sql: true #false 로
     properties:
       hibernate:
         format_sql: true
-    open-in-view: false
+    open-in-view: true # false로
     database: mysql
 
   data:
@@ -55,21 +55,21 @@ spring:
               - profile
               - email
 
-          kakao:
-            client-id: ${KAKAO_CLIENT}
-            client-secret: ${KAKAO_SECRET}
-            redirect-uri: ${KAKAO_REDIRECT_URI}
-            client-authentication-method: client_secret_post
-            authorization-grant-type: authorization_code
-            scope:
-              - profile_nickname
-              - profile_image
-              - account_email
-            client-name: kakao
+        #  kakao:
+        #    client-id: ${KAKAO_CLIENT}
+        #    client-secret: ${KAKAO_SECRET}
+        #    redirect-uri: ${KAKAO_REDIRECT_URI}
+        #    client-authentication-method: client_secret_post
+        #    authorization-grant-type: authorization_code
+        #    scope:
+        #      - profile_nickname
+        #      - profile_image
+        #      - account_email
+        #    client-name: kakao
 
-        provider:
-          kakao:
-            authorization-uri: https://kauth.kakao.com/oauth/authorize
-            token-uri: https://kauth.kakao.com/oauth/token
-            user-info-uri: https://kapi.kakao.com/v2/user/me
-            user-name-attribute: id
+        # provider:
+        #   kakao:
+        #     authorization-uri: https://kauth.kakao.com/oauth/authorize
+        #     token-uri: https://kauth.kakao.com/oauth/token
+        #     user-info-uri: https://kapi.kakao.com/v2/user/me
+        #     user-name-attribute: id

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,11 +17,14 @@ spring:
 
   data:
     redis:
-      host: ${REDIS_HOST:localhost}
-      port: ${REDIS_PORT:6379}
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
 
   jackson:
     property-naming-strategy : SNAKE_CASE
+
+  oauth:
+    default-password: ${OAUTH_DEFAULT_PASSWORD}
 
   jwt:
     header: ${JWT_HEADER}
@@ -29,6 +32,12 @@ spring:
     secret: ${JWT_SECRET}
     accessExpiration: 3600
     refreshExpiration: 604800
+
+  whispy:
+    file:
+      upload-path: ${user.home}/whispy/uploads
+      base-url: http://localhost:8080
+      profile-image-folder: profile
 
   servlet:
     multipart:
@@ -49,7 +58,7 @@ spring:
           kakao:
             client-id: ${KAKAO_CLIENT}
             client-secret: ${KAKAO_SECRET}
-            redirect-uri: http://localhost:8080/login/oauth2/code/kakao
+            redirect-uri: ${KAKAO_REDIRECT_URI}
             client-authentication-method: client_secret_post
             authorization-grant-type: authorization_code
             scope:


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #16 

- **New Features**
  - 카카오 OAuth 액세스 토큰을 검증하고 사용자 정보를 조회하는 기능이 추가되었습니다.
  - 카카오 OAuth 로그인 기능이 도입되어, 카카오 계정으로 간편하게 로그인할 수 있습니다.
  - JWT 토큰 발급을 통한 인증 절차가 개선되었습니다.
- **Bug Fixes**
  - 토큰 만료 및 유효하지 않은 카카오 액세스 토큰 관련 오류 메시지가 한글로 개선되었습니다.
- **Chores**
  - Redis 및 OAuth 관련 환경 변수 설정이 강화되어, 명시적 설정이 필요해졌습니다.
- **Refactor**
  - 일부 서비스의 의존성 및 클래스명이 정리되어 코드 관리가 용이해졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 카카오 OAuth를 통한 사용자 인증 및 로그인 기능이 추가되었습니다.
    - 카카오 액세스 토큰을 이용한 인증 엔드포인트가 도입되었습니다.
    - 카카오 OAuth 관련 예외 및 에러 코드가 추가되었습니다.
    - RestTemplate 빈이 등록되어 외부 API 호출이 가능해졌습니다.

- **버그 수정**
    - 불필요한 import 문이 제거되었습니다.

- **기능 개선**
    - 사용자 비밀번호 유효성 검사가 간소화되었습니다.
    - 사용자 엔터티의 비밀번호 컬럼 길이가 60자에서 70자로 확장되었습니다.
    - OAuth 사용자 생성 시 기본 비밀번호가 환경설정에서 주입되도록 변경되었습니다.
    - 보안 설정이 개선되어 카카오 OAuth 엔드포인트 접근이 허용되었습니다.
    - Google OAuth2 엔드포인트 접근 범위가 명확히 지정되었습니다.

- **설정**
    - JPA SQL 로그 및 open-in-view 설정이 활성화되었습니다.
    - Redis 및 파일 업로드 관련 환경설정이 변경되었습니다.
    - 카카오 OAuth 클라이언트 설정이 주석 처리되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->