### PR TITLE
Feature/39-file-upload-music

### DIFF
--- a/src/main/java/whispy_server/whispy/domain/file/application/service/FileUploadService.java
+++ b/src/main/java/whispy_server/whispy/domain/file/application/service/FileUploadService.java
@@ -25,7 +25,7 @@ public class FileUploadService implements FileUploadUseCase {
 
     @Override
     public FileUploadResponse uploadFile(MultipartFile file, ImageFolder imageFolder) {
-        fileValidator.validateFile(file);
+        fileValidator.validateFile(file, imageFolder);
 
         String fileName = generateFileName(file.getOriginalFilename());
         String folder = imageFolder.toString().toLowerCase();

--- a/src/main/java/whispy_server/whispy/domain/file/application/service/FileValidator.java
+++ b/src/main/java/whispy_server/whispy/domain/file/application/service/FileValidator.java
@@ -64,7 +64,7 @@ public class FileValidator {
 
     private void validateImageExtension(MultipartFile file) {
         String extension = getFileExtension(file);
-        Set<String> validExtensions = Set.of(".jpg", ".jpeg", ".png", ".heic", ".heif", ".svg", ".webp", ".gif");
+        Set<String> validExtensions = Set.of(".jpg", ".jpeg", ".png", ".heic", ".heif", ".webp", ".gif");
 
         if (!validExtensions.contains(extension)) {
             throw FileInvalidExtensionException.EXCEPTION;
@@ -82,8 +82,7 @@ public class FileValidator {
     private void validateImageMimeType(MultipartFile file) {
         String contentType = file.getContentType();
         Set<String> validMimeTypes = Set.of(
-                "image/jpeg", "image/png", "image/heic",
-                "image/svg+xml", "image/webp", "image/gif", "image/heif"
+                "image/jpeg", "image/png", "image/heic", "image/webp", "image/gif", "image/heif"
         );
 
         if (contentType == null || !validMimeTypes.contains(contentType)) {

--- a/src/main/java/whispy_server/whispy/domain/file/application/service/FileValidator.java
+++ b/src/main/java/whispy_server/whispy/domain/file/application/service/FileValidator.java
@@ -3,6 +3,7 @@ package whispy_server.whispy.domain.file.application.service;
 import org.apache.tomcat.util.http.fileupload.InvalidFileNameException;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
+import whispy_server.whispy.domain.file.type.ImageFolder;
 import whispy_server.whispy.global.exception.domain.file.FileInvalidExtensionException;
 import whispy_server.whispy.global.exception.domain.file.FileInvalidMimeTypeException;
 import whispy_server.whispy.global.exception.domain.file.FileNameContainsPathException;
@@ -18,35 +19,16 @@ import java.util.regex.Pattern;
 @Component
 public class FileValidator {
 
-    private static final Set<String> VALID_EXTENSIONS = Set.of(
-            ".jpg", ".jpeg", ".png", ".heic",".heif", ".svg", ".webp", ".gif"
-    );
-
-    // 허용할 MIME 타입
-    private static final Set<String> VALID_MIME_TYPES = Set.of(
-            "image/jpeg", "image/png", "image/heic",
-            "image/svg+xml", "image/webp", "image/gif", "image/heif"
-    );
-
-    private static final long MAX_FILE_SIZE = 5 * 1024 * 1024;
-
     private static final Pattern SAFE_FILENAME_PATTERN = Pattern.compile("^[a-zA-Z0-9._-]+$");
 
-
-
-    public void validateFile(MultipartFile file) {
-
+    public void validateFile(MultipartFile file, ImageFolder folder) {
         validateFileName(file);
 
-        validateFileExtension(file);
-
-        validateMimeType(file);
-
-        validateFileSize(file);
-
-
+        switch (folder) {
+            case PROFILE_IMAGE_FOLDER, MUSIC_BANNER_IMAGE_FOLDER -> validateImageFile(file);
+            case MUSIC_FOLDER -> validateMusicFile(file);
+        }
     }
-
 
     private void validateFileName(MultipartFile file) {
         String originalFileName = file.getOriginalFilename();
@@ -68,27 +50,78 @@ public class FileValidator {
         }
     }
 
-    private void validateFileExtension(MultipartFile file){
-        String originalFileName = file.getOriginalFilename();
-        if(!originalFileName.contains(".")){
-            throw FileNoExtensionException.EXCEPTION;
-        }
-        String extension = originalFileName.substring(originalFileName.lastIndexOf(".")).toLowerCase();
-        if(!VALID_EXTENSIONS.contains(extension)){
+    private void validateImageFile(MultipartFile file) {
+        validateImageExtension(file);
+        validateImageMimeType(file);
+        validateImageSize(file);
+    }
+
+    private void validateMusicFile(MultipartFile file) {
+        validateMusicExtension(file);
+        validateMusicMimeType(file);
+        validateMusicSize(file);
+    }
+
+    private void validateImageExtension(MultipartFile file) {
+        String extension = getFileExtension(file);
+        Set<String> validExtensions = Set.of(".jpg", ".jpeg", ".png", ".heic", ".heif", ".svg", ".webp", ".gif");
+
+        if (!validExtensions.contains(extension)) {
             throw FileInvalidExtensionException.EXCEPTION;
         }
     }
 
-    private void validateMimeType(MultipartFile file){
+    private void validateMusicExtension(MultipartFile file) {
+        String extension = getFileExtension(file);
+        Set<String> validExtensions = Set.of(".mp3", ".wav", ".flac", ".aac", ".ogg", ".m4a");
+
+        if (!validExtensions.contains(extension)) {
+            throw FileInvalidExtensionException.EXCEPTION;
+        }
+    }
+    private void validateImageMimeType(MultipartFile file) {
         String contentType = file.getContentType();
-        if (contentType == null || !VALID_MIME_TYPES.contains(contentType)) {
+        Set<String> validMimeTypes = Set.of(
+                "image/jpeg", "image/png", "image/heic",
+                "image/svg+xml", "image/webp", "image/gif", "image/heif"
+        );
+
+        if (contentType == null || !validMimeTypes.contains(contentType)) {
             throw FileInvalidMimeTypeException.EXCEPTION;
         }
     }
 
-    private void validateFileSize(MultipartFile file) {
-        if (file.getSize() > MAX_FILE_SIZE) {
+    private void validateMusicMimeType(MultipartFile file) {
+        String contentType = file.getContentType();
+        Set<String> validMimeTypes = Set.of(
+                "audio/mpeg", "audio/wav", "audio/flac",
+                "audio/aac", "audio/ogg", "audio/mp4"
+        );
+
+        if (contentType == null || !validMimeTypes.contains(contentType)) {
+            throw FileInvalidMimeTypeException.EXCEPTION;
+        }
+    }
+
+    private void validateImageSize(MultipartFile file) {
+        long maxSize = 5 * 1024 * 1024; // 5MB
+        if (file.getSize() > maxSize) {
             throw FileSizeExceededException.EXCEPTION;
         }
+    }
+
+    private void validateMusicSize(MultipartFile file) {
+        long maxSize = 50 * 1024 * 1024; // 50MB
+        if (file.getSize() > maxSize) {
+            throw FileSizeExceededException.EXCEPTION;
+        }
+    }
+
+    private String getFileExtension(MultipartFile file) {
+        String originalFileName = file.getOriginalFilename();
+        if (originalFileName == null || !originalFileName.contains(".")) {
+            throw FileNoExtensionException.EXCEPTION;
+        }
+        return originalFileName.substring(originalFileName.lastIndexOf(".")).toLowerCase();
     }
 }

--- a/src/main/java/whispy_server/whispy/domain/file/type/ImageFolder.java
+++ b/src/main/java/whispy_server/whispy/domain/file/type/ImageFolder.java
@@ -3,5 +3,7 @@ package whispy_server.whispy.domain.file.type;
 public enum ImageFolder {
 
     PROFILE_IMAGE_FOLDER,
+    MUSIC_FOLDER,
+    MUSIC_BANNER_IMAGE_FOLDER
 
 }

--- a/src/main/java/whispy_server/whispy/global/config/security/SecurityConfig.java
+++ b/src/main/java/whispy_server/whispy/global/config/security/SecurityConfig.java
@@ -71,7 +71,7 @@ public class SecurityConfig {
                         .requestMatchers("/users/login","/users/register","/users/reissue").permitAll()
                         .requestMatchers("/users/oauth/kakao").permitAll()
                         .requestMatchers("/oauth/success/**").permitAll()
-                        .requestMatchers("/file/profile_image_folder/**").permitAll()
+                        .requestMatchers("/file/profile_image_folder/**","/file/music_folder/**").permitAll()
                         .requestMatchers("/auth/email/**").permitAll()
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/v3/api-docs.yaml").permitAll()
 

--- a/src/main/java/whispy_server/whispy/global/config/security/SecurityConfig.java
+++ b/src/main/java/whispy_server/whispy/global/config/security/SecurityConfig.java
@@ -71,7 +71,10 @@ public class SecurityConfig {
                         .requestMatchers("/users/login","/users/register","/users/reissue").permitAll()
                         .requestMatchers("/users/oauth/kakao").permitAll()
                         .requestMatchers("/oauth/success/**").permitAll()
-                        .requestMatchers("/file/profile_image_folder/**","/file/music_folder/**").permitAll()
+                        .requestMatchers("/file/profile_image_folder/**",
+                                         "/file/music_folder/**",
+                                         "/file/music_banner_image_folder/**"
+                        ).permitAll()
                         .requestMatchers("/auth/email/**").permitAll()
                         .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/v3/api-docs.yaml").permitAll()
 

--- a/src/main/java/whispy_server/whispy/global/file/FileProperties.java
+++ b/src/main/java/whispy_server/whispy/global/file/FileProperties.java
@@ -5,8 +5,6 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties("spring.whispy.file")
 public record FileProperties(
         String uploadPath,
-        String baseUrl,
-        String profileImageFolder
-
+        String baseUrl
 ) {
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,6 +4,11 @@ spring:
     url: ${DB_URL}
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
+  
+  servlet:
+    multipart:
+      max-file-size: 50MB
+      max-request-size: 50MB
   jpa:
     hibernate:
       ddl-auto: update
@@ -37,7 +42,6 @@ spring:
     file:
       upload-path: ${UPLOAD_PATH}
       base-url: ${BASE_URL}
-      profile-image-folder: ${PROFILE_IMAGE_FOLDER}
 
   discord:
     webhook:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * 음악 파일 및 음악 배너 이미지 업로드를 지원합니다.
  * 음악 폴더(/file/music_folder/**) 리소스에 공개 접근이 가능합니다.
* Refactor
  * 업로드 대상 폴더별로 파일 확장자·MIME 타입·용량 검증을 세분화했습니다(이미지 최대 5MB, 음악 최대 50MB).
* Chores
  * 서버 멀티파트 업로드 한도를 50MB로 설정했습니다.
  * 사용되지 않는 프로필 이미지 폴더 설정을 제거하고 구성 속성을 정리했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->