### PR TITLE
Feature/41-db-query

### DIFF
--- a/src/main/java/whispy_server/whispy/domain/notification/adapter/in/web/controller/NotificationController.java
+++ b/src/main/java/whispy_server/whispy/domain/notification/adapter/in/web/controller/NotificationController.java
@@ -19,7 +19,6 @@ import whispy_server.whispy.domain.notification.application.port.in.SendToTopicU
 import whispy_server.whispy.global.document.api.notification.NotificationApiDocument;
 
 import java.util.List;
-import java.util.UUID;
 
 @RestController
 @RequestMapping("/notifications")
@@ -62,7 +61,7 @@ public class NotificationController implements NotificationApiDocument {
     }
 
     @PatchMapping("/{notificationId}/read")
-    public void markAsRead(@PathVariable UUID notificationId) {
+    public void markAsRead(@PathVariable Long notificationId) {
         markNotificationAsReadUseCase.execute(notificationId);
     }
 
@@ -72,7 +71,7 @@ public class NotificationController implements NotificationApiDocument {
     }
 
     @DeleteMapping("/{notificationId}")
-    public void deleteNotification(@PathVariable UUID notificationId) {
+    public void deleteNotification(@PathVariable Long notificationId) {
         deleteNotificationUseCase.execute(notificationId);
     }
 

--- a/src/main/java/whispy_server/whispy/domain/notification/adapter/in/web/dto/response/NotificationResponse.java
+++ b/src/main/java/whispy_server/whispy/domain/notification/adapter/in/web/dto/response/NotificationResponse.java
@@ -4,10 +4,9 @@ import whispy_server.whispy.domain.notification.model.Notification;
 import whispy_server.whispy.domain.topic.model.types.NotificationTopic;
 
 import java.util.Map;
-import java.util.UUID;
 
 public record NotificationResponse(
-        UUID id,
+        Long id,
         String email,
         String title,
         String body,

--- a/src/main/java/whispy_server/whispy/domain/notification/adapter/out/entity/NotificationJpaEntity.java
+++ b/src/main/java/whispy_server/whispy/domain/notification/adapter/out/entity/NotificationJpaEntity.java
@@ -10,6 +10,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.MapKeyColumn;
 import jakarta.persistence.Table;
@@ -25,7 +26,11 @@ import java.util.Map;
 import java.util.UUID;
 
 @Entity(name = "NotificationJpaEntity")
-@Table(name = "tbl_notification")
+@Table(name = "tbl_notification", indexes = {
+        @Index(name = "idx_notification_email", columnList = "email"),
+        @Index(name = "idx_notification_email_read", columnList = "email, `read`"),
+        @Index(name = "idx_notification_email_created_at", columnList = "email, created_at")
+})
 @Getter
 @Builder
 @AllArgsConstructor

--- a/src/main/java/whispy_server/whispy/domain/notification/adapter/out/entity/NotificationJpaEntity.java
+++ b/src/main/java/whispy_server/whispy/domain/notification/adapter/out/entity/NotificationJpaEntity.java
@@ -26,11 +26,7 @@ import java.util.Map;
 import java.util.UUID;
 
 @Entity(name = "NotificationJpaEntity")
-@Table(name = "tbl_notification", indexes = {
-        @Index(name = "idx_notification_email", columnList = "email"),
-        @Index(name = "idx_notification_email_read", columnList = "email, `read`"),
-        @Index(name = "idx_notification_email_created_at", columnList = "email, created_at")
-})
+@Table(name = "tbl_notification")
 @Getter
 @Builder
 @AllArgsConstructor

--- a/src/main/java/whispy_server/whispy/domain/notification/adapter/out/entity/NotificationJpaEntity.java
+++ b/src/main/java/whispy_server/whispy/domain/notification/adapter/out/entity/NotificationJpaEntity.java
@@ -10,7 +10,6 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.MapKeyColumn;
 import jakarta.persistence.Table;
@@ -34,8 +33,8 @@ import java.util.UUID;
 public class NotificationJpaEntity extends BaseTimeEntity {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.UUID)
-    private UUID id;
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
 
     @Column(name = "email", nullable = false)
     private String email;

--- a/src/main/java/whispy_server/whispy/domain/notification/adapter/out/persistence/NotificationPersistenceAdapter.java
+++ b/src/main/java/whispy_server/whispy/domain/notification/adapter/out/persistence/NotificationPersistenceAdapter.java
@@ -11,7 +11,6 @@ import whispy_server.whispy.domain.notification.model.Notification;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.UUID;
 
 @Component
 @RequiredArgsConstructor
@@ -22,7 +21,7 @@ public class NotificationPersistenceAdapter implements NotificationPort {
     private final JPAQueryFactory jpaQueryFactory;
 
     @Override
-    public Optional<Notification> findById(UUID id){
+    public Optional<Notification> findById(Long id){
         Optional<NotificationJpaEntity> optionalEntity = notificationRepository.findById(id);
         return mapper.toOptionalModel(optionalEntity);
     }
@@ -61,7 +60,7 @@ public class NotificationPersistenceAdapter implements NotificationPort {
     }
 
     @Override
-    public void deleteById(UUID id) {
+    public void deleteById(Long id) {
         notificationRepository.deleteById(id);
     }
 

--- a/src/main/java/whispy_server/whispy/domain/notification/adapter/out/persistence/repository/NotificationRepository.java
+++ b/src/main/java/whispy_server/whispy/domain/notification/adapter/out/persistence/repository/NotificationRepository.java
@@ -5,9 +5,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import whispy_server.whispy.domain.notification.adapter.out.entity.NotificationJpaEntity;
 
 import java.util.List;
-import java.util.UUID;
 
-public interface NotificationRepository extends JpaRepository<NotificationJpaEntity, UUID> {
+public interface NotificationRepository extends JpaRepository<NotificationJpaEntity, Long> {
 
     @EntityGraph(attributePaths = {"data"})
     List<NotificationJpaEntity> findByEmailOrderByCreatedAtDesc(String email);

--- a/src/main/java/whispy_server/whispy/domain/notification/application/port/in/DeleteNotificationUseCase.java
+++ b/src/main/java/whispy_server/whispy/domain/notification/application/port/in/DeleteNotificationUseCase.java
@@ -2,9 +2,7 @@ package whispy_server.whispy.domain.notification.application.port.in;
 
 import whispy_server.whispy.global.annotation.UseCase;
 
-import java.util.UUID;
-
 @UseCase
 public interface DeleteNotificationUseCase {
-    void execute(UUID notificationId);
+    void execute(Long notificationId);
 }

--- a/src/main/java/whispy_server/whispy/domain/notification/application/port/in/MarkNotificationAsReadUseCase.java
+++ b/src/main/java/whispy_server/whispy/domain/notification/application/port/in/MarkNotificationAsReadUseCase.java
@@ -2,9 +2,7 @@ package whispy_server.whispy.domain.notification.application.port.in;
 
 import whispy_server.whispy.global.annotation.UseCase;
 
-import java.util.UUID;
-
 @UseCase
 public interface MarkNotificationAsReadUseCase {
-    void execute(UUID notificationId);
+    void execute(Long notificationId);
 }

--- a/src/main/java/whispy_server/whispy/domain/notification/application/port/out/DeleteNotificationPort.java
+++ b/src/main/java/whispy_server/whispy/domain/notification/application/port/out/DeleteNotificationPort.java
@@ -1,8 +1,6 @@
 package whispy_server.whispy.domain.notification.application.port.out;
 
-import java.util.UUID;
-
 public interface DeleteNotificationPort {
-    void deleteById(UUID id);
+    void deleteById(Long id);
     void deleteAllByEmail(String email);
 }

--- a/src/main/java/whispy_server/whispy/domain/notification/application/port/out/QueryNotificationPort.java
+++ b/src/main/java/whispy_server/whispy/domain/notification/application/port/out/QueryNotificationPort.java
@@ -4,10 +4,9 @@ import whispy_server.whispy.domain.notification.model.Notification;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.UUID;
 
 public interface QueryNotificationPort {
-    Optional<Notification> findById(UUID notificationId);
+    Optional<Notification> findById(Long notificationId);
     List<Notification> findByEmailOrderByCreatedAtDesc(String email);
     List<Notification> findByEmailAndReadFalseOrderByCreatedAtDesc(String email);
     List<Notification> findByEmailAndIsReadFalse(String email);

--- a/src/main/java/whispy_server/whispy/domain/notification/application/service/DeleteNotificationService.java
+++ b/src/main/java/whispy_server/whispy/domain/notification/application/service/DeleteNotificationService.java
@@ -12,8 +12,6 @@ import whispy_server.whispy.domain.user.application.port.in.UserFacadeUseCase;
 import whispy_server.whispy.domain.user.model.User;
 import whispy_server.whispy.global.exception.domain.fcm.NotificationNotFoundException;
 
-import java.util.UUID;
-
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -24,7 +22,7 @@ public class DeleteNotificationService implements DeleteNotificationUseCase {
     private final UserFacadeUseCase userFacadeUseCase;
 
     @Override
-    public void execute(UUID notificationId) {
+    public void execute(Long notificationId) {
         User currentUser = userFacadeUseCase.currentUser();
         Notification notification = queryNotificationPort.findById(notificationId)
                 .orElseThrow(() -> NotificationNotFoundException.EXCEPTION);

--- a/src/main/java/whispy_server/whispy/domain/notification/application/service/MarkNotificationAsReadService.java
+++ b/src/main/java/whispy_server/whispy/domain/notification/application/service/MarkNotificationAsReadService.java
@@ -11,8 +11,6 @@ import whispy_server.whispy.domain.user.application.port.in.UserFacadeUseCase;
 import whispy_server.whispy.domain.user.model.User;
 import whispy_server.whispy.global.exception.domain.fcm.NotificationNotFoundException;
 
-import java.util.UUID;
-
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -23,7 +21,7 @@ public class MarkNotificationAsReadService implements MarkNotificationAsReadUseC
     private final UserFacadeUseCase userFacadeUseCase;
 
     @Override
-    public void execute(UUID notificationId){
+    public void execute(Long notificationId){
         User currentUser = userFacadeUseCase.currentUser();
         Notification notification = queryNotificationPort.findById(notificationId)
                 .orElseThrow(() -> NotificationNotFoundException.EXCEPTION);

--- a/src/main/java/whispy_server/whispy/domain/notification/model/Notification.java
+++ b/src/main/java/whispy_server/whispy/domain/notification/model/Notification.java
@@ -4,11 +4,10 @@ import whispy_server.whispy.domain.topic.model.types.NotificationTopic;
 import whispy_server.whispy.global.annotation.Aggregate;
 
 import java.util.Map;
-import java.util.UUID;
 
 @Aggregate
 public record Notification(
-        UUID id,
+        Long id,
         String email,
         String title,
         String body,

--- a/src/main/java/whispy_server/whispy/domain/payment/adapter/out/entity/SubscriptionJpaEntity.java
+++ b/src/main/java/whispy_server/whispy/domain/payment/adapter/out/entity/SubscriptionJpaEntity.java
@@ -11,7 +11,11 @@ import whispy_server.whispy.global.entity.BaseTimeEntity;
 import java.time.LocalDateTime;
 
 @Entity(name = "SubscriptionJpaEntity")
-@Table(name = "tbl_subscription")
+@Table(name = "tbl_subscription", indexes = {
+        @Index(name = "idx_subscription_email", columnList = "email"),
+        @Index(name = "idx_subscription_purchase_token", columnList = "purchase_token"),
+        @Index(name = "idx_subscription_email_state", columnList = "email, subscription_state")
+})
 @Getter
 @Builder
 @AllArgsConstructor

--- a/src/main/java/whispy_server/whispy/domain/payment/adapter/out/entity/SubscriptionJpaEntity.java
+++ b/src/main/java/whispy_server/whispy/domain/payment/adapter/out/entity/SubscriptionJpaEntity.java
@@ -13,7 +13,6 @@ import java.time.LocalDateTime;
 @Entity(name = "SubscriptionJpaEntity")
 @Table(name = "tbl_subscription", indexes = {
         @Index(name = "idx_subscription_email", columnList = "email"),
-        @Index(name = "idx_subscription_purchase_token", columnList = "purchase_token"),
         @Index(name = "idx_subscription_email_state", columnList = "email, subscription_state")
 })
 @Getter

--- a/src/main/java/whispy_server/whispy/domain/payment/adapter/out/entity/SubscriptionJpaEntity.java
+++ b/src/main/java/whispy_server/whispy/domain/payment/adapter/out/entity/SubscriptionJpaEntity.java
@@ -1,9 +1,19 @@
 package whispy_server.whispy.domain.payment.adapter.out.entity;
 
-import jakarta.persistence.*;
-import lombok.*;
-import org.hibernate.annotations.CreationTimestamp;
-import org.hibernate.annotations.UpdateTimestamp;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import whispy_server.whispy.domain.payment.model.type.ProductType;
 import whispy_server.whispy.domain.payment.model.type.SubscriptionState;
 import whispy_server.whispy.global.entity.BaseTimeEntity;

--- a/src/main/java/whispy_server/whispy/domain/payment/adapter/out/persistence/SubscriptionPersistenceAdapter.java
+++ b/src/main/java/whispy_server/whispy/domain/payment/adapter/out/persistence/SubscriptionPersistenceAdapter.java
@@ -35,28 +35,13 @@ public class SubscriptionPersistenceAdapter implements SubscriptionSavePort, Que
 
     @Override
     public Optional<Subscription> findByEmail(String email) {
-        SubscriptionJpaEntity entity = jpaQueryFactory
-                .selectFrom(QSubscriptionJpaEntity.subscriptionJpaEntity)
-                .innerJoin(QUserJpaEntity.userJpaEntity)
-                .on(QSubscriptionJpaEntity.subscriptionJpaEntity.email.eq(QUserJpaEntity.userJpaEntity.email))
-                .where(QSubscriptionJpaEntity.subscriptionJpaEntity.email.eq(email))
-                .fetchFirst();
-
-        return subscriptionEntityMapper.toOptionalModel(Optional.ofNullable(entity));
+        return subscriptionEntityMapper.toOptionalModel(subscriptionJpaRepository.findByEmail(email));
     }
 
     @Override
     public Optional<Subscription> findActiveSubscriptionByEmail(String email) {
-        SubscriptionJpaEntity entity = jpaQueryFactory
-                .selectFrom(QSubscriptionJpaEntity.subscriptionJpaEntity)
-                .innerJoin(QUserJpaEntity.userJpaEntity)
-                .on(QSubscriptionJpaEntity.subscriptionJpaEntity.email.eq(QUserJpaEntity.userJpaEntity.email))
-                .where(
-                        QSubscriptionJpaEntity.subscriptionJpaEntity.email.eq(email)
-                                .and(QSubscriptionJpaEntity.subscriptionJpaEntity.subscriptionState.eq(SubscriptionState.ACTIVE))
-                )
-                .fetchFirst();
-
-        return subscriptionEntityMapper.toOptionalModel(Optional.ofNullable(entity));
+        return subscriptionEntityMapper.toOptionalModel(
+                subscriptionJpaRepository.findByEmailAndSubscriptionState(email, SubscriptionState.ACTIVE)
+        );
     }
 }

--- a/src/main/java/whispy_server/whispy/domain/payment/adapter/out/persistence/repository/SubscriptionJpaRepository.java
+++ b/src/main/java/whispy_server/whispy/domain/payment/adapter/out/persistence/repository/SubscriptionJpaRepository.java
@@ -11,4 +11,8 @@ import java.util.Optional;
 public interface SubscriptionJpaRepository extends JpaRepository<SubscriptionJpaEntity, Long> {
 
     Optional<SubscriptionJpaEntity> findByPurchaseToken(String purchaseToken);
+
+    Optional<SubscriptionJpaEntity> findByEmail(String email);
+
+    Optional<SubscriptionJpaEntity> findByEmailAndSubscriptionState(String email, SubscriptionState state);
 }

--- a/src/main/java/whispy_server/whispy/domain/topic/adapter/in/web/dto/response/TopicSubscriptionResponse.java
+++ b/src/main/java/whispy_server/whispy/domain/topic/adapter/in/web/dto/response/TopicSubscriptionResponse.java
@@ -3,10 +3,8 @@ package whispy_server.whispy.domain.topic.adapter.in.web.dto.response;
 import whispy_server.whispy.domain.topic.model.TopicSubscription;
 import whispy_server.whispy.domain.topic.model.types.NotificationTopic;
 
-import java.util.UUID;
-
 public record TopicSubscriptionResponse(
-        UUID id,
+        Long id,
         String email,
         NotificationTopic topic,
         boolean Subscribed

--- a/src/main/java/whispy_server/whispy/domain/topic/adapter/out/entity/TopicSubscriptionJpaEntity.java
+++ b/src/main/java/whispy_server/whispy/domain/topic/adapter/out/entity/TopicSubscriptionJpaEntity.java
@@ -9,6 +9,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Index;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -20,7 +21,11 @@ import whispy_server.whispy.domain.topic.model.types.NotificationTopic;
 @Table(name = "tbl_topic_subscription", indexes = {
         @Index(name = "idx_topic_sub_email", columnList = "email"),
         @Index(name = "idx_topic_sub_topic_subscribed", columnList = "topic, subscribed")
-})
+    },
+        uniqueConstraints = {
+            @UniqueConstraint(name = "uk_topic_sub_email_topic", columnNames = {"email", "topic"})
+    }
+)
 @Getter
 @Builder
 @AllArgsConstructor

--- a/src/main/java/whispy_server/whispy/domain/topic/adapter/out/entity/TopicSubscriptionJpaEntity.java
+++ b/src/main/java/whispy_server/whispy/domain/topic/adapter/out/entity/TopicSubscriptionJpaEntity.java
@@ -7,6 +7,7 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -18,7 +19,11 @@ import whispy_server.whispy.domain.topic.model.types.NotificationTopic;
 import java.util.UUID;
 
 @Entity(name = "TopicSubscriptionJpaEntity")
-@Table(name = "tbl_topic_subscription")
+@Table(name = "tbl_topic_subscription", indexes = {
+        @Index(name = "idx_topic_sub_email", columnList = "email"),
+        @Index(name = "idx_topic_sub_topic_subscribed", columnList = "topic, subscribed"),
+        @Index(name = "idx_topic_sub_email_topic", columnList = "email, topic")
+})
 @Getter
 @Builder
 @AllArgsConstructor

--- a/src/main/java/whispy_server/whispy/domain/topic/adapter/out/entity/TopicSubscriptionJpaEntity.java
+++ b/src/main/java/whispy_server/whispy/domain/topic/adapter/out/entity/TopicSubscriptionJpaEntity.java
@@ -21,8 +21,7 @@ import java.util.UUID;
 @Entity(name = "TopicSubscriptionJpaEntity")
 @Table(name = "tbl_topic_subscription", indexes = {
         @Index(name = "idx_topic_sub_email", columnList = "email"),
-        @Index(name = "idx_topic_sub_topic_subscribed", columnList = "topic, subscribed"),
-        @Index(name = "idx_topic_sub_email_topic", columnList = "email, topic")
+        @Index(name = "idx_topic_sub_topic_subscribed", columnList = "topic, subscribed")
 })
 @Getter
 @Builder

--- a/src/main/java/whispy_server/whispy/domain/topic/adapter/out/entity/TopicSubscriptionJpaEntity.java
+++ b/src/main/java/whispy_server/whispy/domain/topic/adapter/out/entity/TopicSubscriptionJpaEntity.java
@@ -16,8 +16,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import whispy_server.whispy.domain.topic.model.types.NotificationTopic;
 
-import java.util.UUID;
-
 @Entity(name = "TopicSubscriptionJpaEntity")
 @Table(name = "tbl_topic_subscription", indexes = {
         @Index(name = "idx_topic_sub_email", columnList = "email"),
@@ -30,8 +28,8 @@ import java.util.UUID;
 public class TopicSubscriptionJpaEntity {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.UUID)
-    private UUID id;
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
 
     @Column(name = "email", nullable = false)
     private String email;

--- a/src/main/java/whispy_server/whispy/domain/topic/adapter/out/persistence/repository/TopicSubscriptionRepository.java
+++ b/src/main/java/whispy_server/whispy/domain/topic/adapter/out/persistence/repository/TopicSubscriptionRepository.java
@@ -6,9 +6,8 @@ import whispy_server.whispy.domain.topic.model.types.NotificationTopic;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.UUID;
 
-public interface TopicSubscriptionRepository extends JpaRepository<TopicSubscriptionJpaEntity, UUID> {
+public interface TopicSubscriptionRepository extends JpaRepository<TopicSubscriptionJpaEntity, Long> {
 
     List<TopicSubscriptionJpaEntity> findByEmail(String email);
 

--- a/src/main/java/whispy_server/whispy/domain/topic/model/TopicSubscription.java
+++ b/src/main/java/whispy_server/whispy/domain/topic/model/TopicSubscription.java
@@ -3,11 +3,9 @@ package whispy_server.whispy.domain.topic.model;
 import whispy_server.whispy.domain.topic.model.types.NotificationTopic;
 import whispy_server.whispy.global.annotation.Aggregate;
 
-import java.util.UUID;
-
 @Aggregate
 public record TopicSubscription(
-        UUID id,
+        Long id,
         String email,
         NotificationTopic topic,
         boolean subscribed

--- a/src/main/java/whispy_server/whispy/domain/user/adapter/out/entity/UserJpaEntity.java
+++ b/src/main/java/whispy_server/whispy/domain/user/adapter/out/entity/UserJpaEntity.java
@@ -51,9 +51,6 @@ public class UserJpaEntity {
     @Enumerated(EnumType.STRING)
     private Role role;
 
-    @Column(name = "coin", nullable = false)
-    private int coin;
-
     @Column(name = "provider", nullable = false)
     private String provider;
 

--- a/src/main/java/whispy_server/whispy/domain/user/adapter/out/entity/UserJpaEntity.java
+++ b/src/main/java/whispy_server/whispy/domain/user/adapter/out/entity/UserJpaEntity.java
@@ -16,9 +16,6 @@ import lombok.NoArgsConstructor;
 import whispy_server.whispy.global.security.jwt.domain.entity.types.Role;
 import whispy_server.whispy.domain.user.model.types.Gender;
 
-
-import java.util.UUID;
-
 @Entity(name = "UserJpaEntity")
 @Table(name = "tbl_user")
 @Getter
@@ -28,8 +25,8 @@ import java.util.UUID;
 public class UserJpaEntity {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.UUID)
-    private UUID id;
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
 
     @Column(name = "email", nullable = false, unique = true)
     private String email;

--- a/src/main/java/whispy_server/whispy/domain/user/adapter/out/persistence/UserPersistenceAdapter.java
+++ b/src/main/java/whispy_server/whispy/domain/user/adapter/out/persistence/UserPersistenceAdapter.java
@@ -9,7 +9,6 @@ import whispy_server.whispy.domain.user.application.port.out.UserPort;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.UUID;
 
 @Component
 @RequiredArgsConstructor
@@ -29,19 +28,12 @@ public class UserPersistenceAdapter implements UserPort {
     }
 
     @Override
-    public List<User> findUserAll() {
-        return userRepository.findAll().stream()
-                .map(userEntityMapper::toModel)
-                .toList();
-    }
-
-    @Override
     public boolean existsByEmail(String email) {
         return userRepository.existsByEmail(email);
     }
 
     @Override
-    public void deleteByUUID(UUID id){
+    public void deleteById(Long id){
         userRepository.deleteById(id);
     }
 }

--- a/src/main/java/whispy_server/whispy/domain/user/adapter/out/persistence/repository/UserRepository.java
+++ b/src/main/java/whispy_server/whispy/domain/user/adapter/out/persistence/repository/UserRepository.java
@@ -4,9 +4,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import whispy_server.whispy.domain.user.adapter.out.entity.UserJpaEntity;
 
 import java.util.Optional;
-import java.util.UUID;
 
-public interface UserRepository extends JpaRepository<UserJpaEntity, UUID> {
+public interface UserRepository extends JpaRepository<UserJpaEntity, Long> {
 
     Optional<UserJpaEntity> findByEmail(String email);
 

--- a/src/main/java/whispy_server/whispy/domain/user/application/port/out/QueryUserPort.java
+++ b/src/main/java/whispy_server/whispy/domain/user/application/port/out/QueryUserPort.java
@@ -2,14 +2,11 @@ package whispy_server.whispy.domain.user.application.port.out;
 
 import whispy_server.whispy.domain.user.model.User;
 
-import java.util.List;
 import java.util.Optional;
 
 public interface QueryUserPort {
 
     Optional<User> findByEmail(String email);
-
-    List<User> findUserAll();
 
 }
 

--- a/src/main/java/whispy_server/whispy/domain/user/application/port/out/UserDeletePort.java
+++ b/src/main/java/whispy_server/whispy/domain/user/application/port/out/UserDeletePort.java
@@ -1,8 +1,6 @@
 package whispy_server.whispy.domain.user.application.port.out;
 
-import java.util.UUID;
-
 public interface UserDeletePort {
 
-    void deleteByUUID(UUID id);
+    void deleteById(Long id);
 }

--- a/src/main/java/whispy_server/whispy/domain/user/application/service/OauthUserService.java
+++ b/src/main/java/whispy_server/whispy/domain/user/application/service/OauthUserService.java
@@ -35,7 +35,6 @@ public class OauthUserService implements OauthUserUseCase {
                             defaultPassword,
                             new Profile(oauthUserInfo.name(), oauthUserInfo.profileImage(), Gender.UNKNOWN),
                             Role.USER,
-                            0,
                             provider.toUpperCase(),
                             null
                     );

--- a/src/main/java/whispy_server/whispy/domain/user/application/service/UserRegisterService.java
+++ b/src/main/java/whispy_server/whispy/domain/user/application/service/UserRegisterService.java
@@ -48,7 +48,6 @@ public class UserRegisterService implements UserRegisterUseCase {
                 encodedPassword,
                 profile,
                 Role.USER,
-                0,
                 DEFAULT_PROVIDER,
                 request.fcmToken()
         );

--- a/src/main/java/whispy_server/whispy/domain/user/application/service/UserWithdrawalService.java
+++ b/src/main/java/whispy_server/whispy/domain/user/application/service/UserWithdrawalService.java
@@ -22,6 +22,6 @@ public class UserWithdrawalService implements UserWithdrawalUseCase {
     public void withdrawal(){
         User currentUser = userFacadeUseCase.currentUser();
         refreshTokenRepository.deleteById(currentUser.email());
-        userDeletePort.deleteByUUID(currentUser.id());
+        userDeletePort.deleteById(currentUser.id());
     }
 }

--- a/src/main/java/whispy_server/whispy/domain/user/model/User.java
+++ b/src/main/java/whispy_server/whispy/domain/user/model/User.java
@@ -1,14 +1,12 @@
 package whispy_server.whispy.domain.user.model;
 
-import java.util.UUID;
-
 import whispy_server.whispy.global.security.jwt.domain.entity.types.Role;
 import whispy_server.whispy.domain.user.model.vo.Profile;
 import whispy_server.whispy.global.annotation.Aggregate;
 
 @Aggregate
 public record User(
-        UUID id,
+        Long id,
         String email,
         String password,
         Profile profile,

--- a/src/main/java/whispy_server/whispy/domain/user/model/User.java
+++ b/src/main/java/whispy_server/whispy/domain/user/model/User.java
@@ -23,7 +23,6 @@ public record User(
                 this.password,
                 this.profile,
                 this.role,
-                this.coin,
                 this.provider,
                 newFcmToken
         );

--- a/src/main/java/whispy_server/whispy/domain/user/model/User.java
+++ b/src/main/java/whispy_server/whispy/domain/user/model/User.java
@@ -11,7 +11,6 @@ public record User(
         String password,
         Profile profile,
         Role role,
-        int coin,
         String provider,
         String fcmToken
 

--- a/src/main/java/whispy_server/whispy/global/document/api/notification/NotificationApiDocument.java
+++ b/src/main/java/whispy_server/whispy/global/document/api/notification/NotificationApiDocument.java
@@ -73,7 +73,7 @@ public interface NotificationApiDocument {
             @ApiResponse(responseCode = "404", description = "알림을 찾을 수 없습니다"),
             @ApiResponse(responseCode = "500", description = "서버 오류 발생")
     })
-    void markAsRead(@Parameter(description = "알림 ID", required = true, in = ParameterIn.PATH) UUID notificationId);
+    void markAsRead(@Parameter(description = "알림 ID", required = true, in = ParameterIn.PATH) Long notificationId);
 
     @Operation(summary = "모든 알림 읽음 처리", description = "현재 사용자의 모든 알림을 읽음 상태로 변경합니다.")
     @ApiResponses({
@@ -91,7 +91,7 @@ public interface NotificationApiDocument {
             @ApiResponse(responseCode = "404", description = "알림을 찾을 수 없습니다"),
             @ApiResponse(responseCode = "500", description = "서버 오류 발생")
     })
-    void deleteNotification(@Parameter(description = "알림 ID", required = true, in = ParameterIn.PATH) UUID notificationId);
+    void deleteNotification(@Parameter(description = "알림 ID", required = true, in = ParameterIn.PATH) Long notificationId);
 
     @Operation(summary = "모든 알림 삭제", description = "현재 사용자의 모든 알림을 삭제합니다.")
     @ApiResponses({


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - 알림, 토픽 구독, 사용자 등 전반의 식별자를 UUID에서 숫자 ID(Long)로 통일했습니다. 관련 API 경로 파라미터와 응답의 ID 표시가 숫자형으로 변경됩니다.
- Documentation
  - 알림 읽음 처리/삭제 API 문서를 숫자형(notificationId: Long)으로 업데이트했습니다.
- Chores
  - 구독/토픽 구독 테이블에 인덱스를 추가해 이메일 및 상태 기반 조회 성능을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->